### PR TITLE
[FIX] smile_web_auto_refresh: no refresh on form

### DIFF
--- a/smile_web_auto_refresh/__manifest__.py
+++ b/smile_web_auto_refresh/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     'name': 'Auto Refresh',
-    'version': '0.1',
+    'version': '12.0.1.0.1',
     'depends': [
         'web',
         'bus',

--- a/smile_web_auto_refresh/static/src/js/web_auto_refresh.js
+++ b/smile_web_auto_refresh/static/src/js/web_auto_refresh.js
@@ -62,7 +62,7 @@ odoo.define('web_auto_refresh', function (require) {
                     } else if (typeof(widget.controllers) != 'undefined') {
                         var controller = widget.getCurrentController();
                         var action = widget.getCurrentAction();
-                        if (action && action.auto_search && controller.widget.modelName == message && controller.widget.mode != "edit") {
+                        if (action && action.auto_search && controller.widget.modelName == message && controller.widget.mode != "edit" && controller.viewType !== 'form') {
                             controller.widget.reload();
                         }
                     }


### PR DESCRIPTION
When refresh is triggered on form, it can interrupt user from sending
messages.